### PR TITLE
Multiple polluters

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/diagnosis/TestDiagnoser.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/diagnosis/TestDiagnoser.java
@@ -36,7 +36,12 @@ public class TestDiagnoser {
         System.out.println();
         System.out.println("-----------------------------------------------------------------");
         System.out.println("Running diagnoser for " + minimized.dependentTest() + " (expected result in this order: " + minimized.expected() + ")");
-        System.out.println(minimized.deps().size() + " known dependencies: " + minimized.deps());
+        if (minimized.polluters().size() > 0) { // Did it find any polluters? Print for first one
+            System.out.println(minimized.polluters().get(0).deps().size() + " known dependencies: " + minimized.polluters().get(0).deps());
+        }
+        else {
+            System.out.println("Found not polluters");
+        }
 
         this.tracer = new StaticFieldInfo(runner, minimized).get();
     }

--- a/src/main/java/edu/illinois/cs/dt/tools/diagnosis/TestDiagnoser.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/diagnosis/TestDiagnoser.java
@@ -37,10 +37,9 @@ public class TestDiagnoser {
         System.out.println("-----------------------------------------------------------------");
         System.out.println("Running diagnoser for " + minimized.dependentTest() + " (expected result in this order: " + minimized.expected() + ")");
         if (minimized.polluters().size() > 0) { // Did it find any polluters? Print for first one
-            System.out.println(minimized.polluters().get(0).deps().size() + " known dependencies: " + minimized.polluters().get(0).deps());
-        }
-        else {
-            System.out.println("Found not polluters");
+            System.out.println(minimized.getFirstDeps().size() + " known dependencies: " + minimized.getFirstDeps());
+        } else {
+            System.out.println("Found no polluters");
         }
 
         this.tracer = new StaticFieldInfo(runner, minimized).get();

--- a/src/main/java/edu/illinois/cs/dt/tools/diagnosis/pollution/Pollution.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/diagnosis/pollution/Pollution.java
@@ -62,7 +62,10 @@ public class Pollution extends FileCache<Map<String, PollutedField>> {
 
             StaticFieldPathManager.createModePath(TracerMode.FIRST_ACCESS);
 
-            if (minimized.deps().isEmpty()) {
+            if (minimized.polluters().isEmpty()) {
+                return new HashMap<>();
+            }
+            if (minimized.polluters().get(0).deps().isEmpty()) {
                 return new HashMap<>();
             }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/diagnosis/pollution/Pollution.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/diagnosis/pollution/Pollution.java
@@ -62,10 +62,7 @@ public class Pollution extends FileCache<Map<String, PollutedField>> {
 
             StaticFieldPathManager.createModePath(TracerMode.FIRST_ACCESS);
 
-            if (minimized.polluters().isEmpty()) {
-                return new HashMap<>();
-            }
-            if (minimized.polluters().get(0).deps().isEmpty()) {
+            if (minimized.getFirstDeps().isEmpty()) {
                 return new HashMap<>();
             }
 

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
@@ -70,27 +70,32 @@ public class MinimizeTestsResult {
 
     public boolean verify(final Runner runner, final int verifyCount) throws Exception {
         for (PolluterData polluter : polluters) {
-            for (int i = 0; i < verifyCount; i++) {
-                List<String> deps = polluter.deps();
-                final List<List<String>> depLists = ListUtil.sample(ListUtil.subsequences(deps), MAX_SUBSEQUENCES);
-                int check = 1;
-                int totalChecks = 2 + depLists.size() - 1;
+            try {
+                for (int i = 0; i < verifyCount; i++) {
+                    List<String> deps = polluter.deps();
+                    final List<List<String>> depLists = ListUtil.sample(ListUtil.subsequences(deps), MAX_SUBSEQUENCES);
+                    int check = 1;
+                    int totalChecks = 2 + depLists.size() - 1;
 
-                IOUtil.printClearLine(String.format("Verifying %d of %d. Running check %d of %d.", i + 1, verifyCount, check++, totalChecks));
-                // Check that it's correct with the dependencies
-                if (!isExpected(runner, deps)) {
-                    throw new MinimizeTestListException("Got unexpected result when running with all dependencies!");
+                    IOUtil.printClearLine(String.format("Verifying %d of %d. Running check %d of %d.", i + 1, verifyCount, check++, totalChecks));
+                    // Check that it's correct with the dependencies
+                    if (!isExpected(runner, deps)) {
+                        throw new MinimizeTestListException("Got unexpected result when running with all dependencies!");
+                    }
+
+                    // Only run the first check if there are no dependencies.
+                    if (deps.isEmpty()) {
+                        continue;
+                    }
+
+                    verifyDependencies(runner, verifyCount, i, deps, depLists, check, totalChecks);
                 }
 
-                // Only run the first check if there are no dependencies.
-                if (deps.isEmpty()) {
-                    continue;
-                }
-
-                verifyDependencies(runner, verifyCount, i, deps, depLists, check, totalChecks);
+                System.out.println();
+            } catch (MinimizeTestListException ex) {
+                System.out.println("Got exception when trying to verify dependencies: " + polluter.deps());
+                ex.printStackTrace();
             }
-
-            System.out.println();
         }
 
         return true;

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
@@ -69,6 +69,7 @@ public class MinimizeTestsResult {
     }
 
     public boolean verify(final Runner runner, final int verifyCount) throws Exception {
+        List<PolluterData> pollutersToRemove = new ArrayList<>();
         for (PolluterData polluter : polluters) {
             try {
                 for (int i = 0; i < verifyCount; i++) {
@@ -95,8 +96,10 @@ public class MinimizeTestsResult {
             } catch (MinimizeTestListException ex) {
                 System.out.println("Got exception when trying to verify dependencies: " + polluter.deps());
                 ex.printStackTrace();
+                pollutersToRemove.add(polluter);
             }
         }
+        polluters.removeAll(pollutersToRemove);
 
         return true;
     }

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
@@ -142,6 +142,13 @@ public class MinimizeTestsResult {
         return polluters;
     }
 
+    public List<String> getFirstDeps() {
+        if (polluters.isEmpty()) {
+            return new ArrayList<String>();
+        }
+        return polluters.get(0).deps();
+    }
+
     public String dependentTest() {
         return dependentTest;
     }
@@ -151,7 +158,7 @@ public class MinimizeTestsResult {
     }
 
     public List<String> withDeps() {
-        final List<String> order = new ArrayList<>(polluters.get(0).deps());    // TODO: What should this return?
+        final List<String> order = new ArrayList<>(getFirstDeps()); // TODO: What should this return?
         if (!order.contains(dependentTest())) {
             order.add(dependentTest());
         }

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/MinimizeTestsResult.java
@@ -87,7 +87,7 @@ public class MinimizeTestsResult {
                     continue;
                 }
 
-                verifyDependencies(runner, verifyCount, i, depLists, check, totalChecks);
+                verifyDependencies(runner, verifyCount, i, deps, depLists, check, totalChecks);
             }
 
             System.out.println();
@@ -99,27 +99,25 @@ public class MinimizeTestsResult {
     private void verifyDependencies(final Runner runner,
                                     final int verifyCount,
                                     final int i,
+                                    final List<String> deps,
                                     final List<List<String>> depLists,
                                     int check,
                                     final int totalChecks) throws Exception {
         IOUtil.printClearLine(String.format("Verifying %d of %d. Running check %d of %d.", i + 1, verifyCount, check++, totalChecks));
-        for (PolluterData polluter : polluters) {
-            List<String> deps = polluter.deps();
-            // Check that it's wrong without dependencies.
-            if (isExpected(runner, new ArrayList<>())) {
-                throw new MinimizeTestListException("Got expected result even without any dependencies!");
+        // Check that it's wrong without dependencies.
+        if (isExpected(runner, new ArrayList<>())) {
+            throw new MinimizeTestListException("Got expected result even without any dependencies!");
+        }
+
+        // Check that for any subsequence that isn't the whole list, it's wrong.
+        for (final List<String> depList : depLists) {
+            if (depList.equals(deps)) {
+                continue;
             }
 
-            // Check that for any subsequence that isn't the whole list, it's wrong.
-            for (final List<String> depList : depLists) {
-                if (depList.equals(deps)) {
-                    continue;
-                }
-
-                IOUtil.printClearLine(String.format("Verifying %d of %d. Running check %d of %d.",  i + 1, verifyCount, check++, totalChecks));
-                if (isExpected(runner, depList)) {
-                    throw new MinimizeTestListException("Got expected result without some dependencies! " + depList);
-                }
+            IOUtil.printClearLine(String.format("Verifying %d of %d. Running check %d of %d.",  i + 1, verifyCount, check++, totalChecks));
+            if (isExpected(runner, depList)) {
+                throw new MinimizeTestListException("Got expected result without some dependencies! " + depList);
             }
         }
     }

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/PolluterData.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/PolluterData.java
@@ -17,4 +17,8 @@ public class PolluterData {
     public List<String> deps() {
         return deps;
     }
+
+    public CleanerData cleanerData() {
+        return cleanerData;
+    }
 }

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/PolluterData.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/PolluterData.java
@@ -1,0 +1,20 @@
+package edu.illinois.cs.dt.tools.minimizer;
+
+import java.util.List;
+
+import edu.illinois.cs.dt.tools.minimizer.cleaner.CleanerData;
+
+public class PolluterData {
+
+    private final List<String> deps;
+    private final CleanerData cleanerData;
+
+    public PolluterData(final List<String> deps, final CleanerData cleanerData) {
+        this.deps = deps;
+        this.cleanerData = cleanerData;
+    }
+
+    public List<String> deps() {
+        return deps;
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/minimizer/TestMinimizer.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/minimizer/TestMinimizer.java
@@ -84,8 +84,14 @@ public class TestMinimizer extends FileCache<MinimizeTestsResult> {
 
             // Keep going as long as there are tests besides dependent test to run
             List<PolluterData> polluters = new ArrayList<>();
-            while (order.size() > 1) {
-                final List<String> deps = run(order);
+            while (!order.isEmpty()) {
+                // First need to check if remaining tests in order still lead to expected value
+                if (result(order) != expected) {
+                    info("Remaining tests no longer match expected: " + order);
+                    break;
+                }
+
+                final List<String> deps = run(new ArrayList<>(order));
                 if (deps.isEmpty()) {
                     info("Did not find any deps");
                     break;


### PR DESCRIPTION
This PR modifies the minimizer logic to look for multiple polluters. The new data structure PolluterData holds both deps and the cleaners for those deps, and the MinimizeTestsResult data structure now holds multiple PolluterData instances.