### PR TITLE
Cleaner Fixer Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>4.3</version>

--- a/src/main/java/edu/illinois/cs/dt/tools/diagnosis/DiagnoserPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/diagnosis/DiagnoserPlugin.java
@@ -44,7 +44,7 @@ public class DiagnoserPlugin extends TestPlugin {
         System.out.println("DIAGNOSER_MODULE_COORDINATES: " + logger.coordinates());
 
         logger.runAndLogError(() -> {
-            writeSubjectProperties(logger.coordinates());
+            logger.writeSubjectProperties();
 
             if (runnerOption.isDefined()) {
                 this.runner = InstrumentingSmartRunner.fromRunner(runnerOption.get());
@@ -64,23 +64,6 @@ public class DiagnoserPlugin extends TestPlugin {
 
             return null;
         });
-    }
-
-    private void writeSubjectProperties(final String coordinates) throws IOException {
-        final Properties properties = new Properties();
-        properties.setProperty("subject.coordinates", coordinates);
-        properties.setProperty("subject.name", subjectName(project));
-
-        Files.createDirectories(DiagnoserPathManager.subjectProperties().getParent());
-        properties.store(new FileOutputStream(DiagnoserPathManager.subjectProperties().toFile()), "");
-    }
-
-    private String subjectName(final MavenProject project) {
-        final Path relativePath =
-                PathManager.parentPath().getParent().toAbsolutePath()
-                        .relativize(project.getBasedir().toPath().toAbsolutePath());
-
-        return relativePath.toString().replace("/", "-");
     }
 
     private void diagnose() throws Exception {

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
@@ -1,0 +1,211 @@
+package edu.illinois.cs.dt.tools.fixer;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.stmt.Statement;
+import com.reedoei.eunomia.collections.ListUtil;
+import com.reedoei.testrunner.mavenplugin.TestPlugin;
+import com.reedoei.testrunner.mavenplugin.TestPluginPlugin;
+import com.reedoei.testrunner.runner.Runner;
+import com.reedoei.testrunner.runner.RunnerFactory;
+import edu.illinois.cs.dt.tools.detection.DetectorPathManager;
+import edu.illinois.cs.dt.tools.detection.DetectorPlugin;
+import edu.illinois.cs.dt.tools.runner.InstrumentingSmartRunner;
+import edu.illinois.cs.dt.tools.utility.ErrorLogger;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import scala.Option;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+public class CleanerFixerPlugin extends TestPlugin {
+    private String classpath;
+    private MavenProject project;
+    private InstrumentingSmartRunner runner;
+
+    // Don't delete. Need a default constructor for TestPlugin
+    public CleanerFixerPlugin() {
+    }
+
+    private boolean testOrderPasses(final List<String> tests) {
+        return new FailingTestDetector(runner).notPassingTests(tests).orElse(new HashSet<>()).isEmpty();
+    }
+
+    private String classpath() throws DependencyResolutionRequiredException {
+        final List<String> elements = new ArrayList<>(project.getCompileClasspathElements());
+        elements.addAll(project.getRuntimeClasspathElements());
+        elements.addAll(project.getTestClasspathElements());
+
+        return String.join(File.pathSeparator, elements);
+    }
+
+    @Override
+    public void execute(final MavenProject project) {
+        this.project = project;
+
+        final Option<Runner> runnerOption = RunnerFactory.from(project);
+        final ErrorLogger logger = new ErrorLogger(project);
+
+        System.out.println("DIAGNOSER_MODULE_COORDINATES: " + logger.coordinates());
+
+        logger.runAndLogError(() -> {
+            logger.writeSubjectProperties();
+            this.classpath = classpath();
+
+            if (runnerOption.isDefined()) {
+                this.runner = InstrumentingSmartRunner.fromRunner(runnerOption.get());
+
+                if (!Files.exists(DetectorPathManager.originalOrderPath())) {
+                    Files.write(DetectorPathManager.originalOrderPath(), DetectorPlugin.getOriginalOrder(project));
+                }
+
+                // TODO: Modify so that it will read parameters directly from the
+                setupAndApplyFix();
+            } else {
+                final String errorMsg = "Module is not using a supported test framework (probably not JUnit).";
+                TestPluginPlugin.info(errorMsg);
+                logger.writeError(errorMsg);
+            }
+
+            return null;
+        });
+    }
+
+    private void setupAndApplyFix() throws Exception {
+        // Get all test source files
+        final List<Path> testFiles = new ArrayList<>();
+        try (final Stream<Path> paths = Files.walk(Paths.get(project.getBuild().getTestSourceDirectory()))) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(testFiles::add);
+        }
+
+        // TODO: Remove these and read from minimized files
+        final String polluterTestName = System.getProperty("dt_fixer.polluter");
+        final String cleanerTestName = System.getProperty("dt_fixer.cleaner");
+        final String victimTestName = System.getProperty("dt_fixer.victim");
+
+        final Optional<JavaMethod> cleanerMethodOpt = JavaMethod.find(cleanerTestName, testFiles, classpath);
+        final Optional<JavaMethod> victimMethodOpt = JavaMethod.find(victimTestName, testFiles, classpath);
+
+        if (!cleanerMethodOpt.isPresent()) {
+            TestPluginPlugin.error("Could not find method " + cleanerTestName);
+            TestPluginPlugin.error("Tried looking in: " + testFiles);
+            return;
+        }
+
+        if (!victimMethodOpt.isPresent()) {
+            TestPluginPlugin.error("Could not find method " + victimTestName);
+            TestPluginPlugin.error("Tried looking in: " + testFiles);
+            return;
+        }
+
+        applyFix(polluterTestName, cleanerMethodOpt.get(), victimMethodOpt.get());
+    }
+
+    private void backup(final JavaFile javaFile) throws IOException {
+        final Path path = CleanerPathManager.backupPath(javaFile.path());
+        Files.copy(javaFile.path(), path, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    // TODO: Extract this logic out to a more generalized fixer that is separate, so we can reuse it
+    // TODO: for cleaners, santa clauses, etc.
+    private void applyFix(final String polluterName,
+                          final JavaMethod cleanerMethod,
+                          final JavaMethod victimMethod) throws Exception {
+        backup(victimMethod.javaFile());
+
+        // Compile the test without our fix
+//        tryRecompile(victimMethod.javaFile());
+
+        runMvnInstall();
+
+        // Check if we pass in isolation before fix
+        // TODO: We should get rid of this check eventually, because it won't work for the case of \santaClause
+        TestPluginPlugin.info("Running victim test in isolation without code from cleaner.");
+        if (!testOrderPasses(Collections.singletonList(victimMethod.methodName()))) {
+            TestPluginPlugin.error("Test fails in isolation");
+            return;
+        }
+
+        // Do our fix
+        TestPluginPlugin.info("Applying code from cleaner and recompiling.");
+        final NodeList<Statement> cleanerStmts = cleanerMethod.body().getStatements();
+
+        // Note: this modifies victimMethod, so when we eventually make it delta-debug, we will want
+        // to make a copy of the victimMethod somewhere
+        victimMethod.prepend(cleanerStmts);
+        victimMethod.javaFile().writeAndReloadCompilationUnit();
+
+        // Check if we pass in isolation after fix
+//        tryRecompile(victimMethod.javaFile());
+        runMvnInstall();
+
+        // TODO: Output to result files rather than stdout
+        TestPluginPlugin.info("Running victim test in isolation with code from cleaner.");
+        boolean passInIsolationAfterFix = testOrderPasses(ListUtil.fromArray(polluterName, victimMethod.methodName()));
+        if (!passInIsolationAfterFix) {
+            TestPluginPlugin.error("Fix was unsuccessful. Test still fails with polluter.");
+        } else {
+            TestPluginPlugin.info("Fix was successful! Fixed file:\n" + victimMethod.javaFile().path());
+        }
+
+        // TODO: What is this for?
+        // Check if we pass in the whole test class
+        // Should check before fix if class is passing
+        //        boolean didClassPass = didTestsPass(victimJavaFile.getTestListAsString());
+
+        //        if (didClassPass) {
+        //            boolean didClassPassAfterFix = didTestsPass(victimJavaFile.getTestListAsString());
+        //            if (!didClassPassAfterFix) {
+        //                System.out.println("Fix was unsuccessful. Fix causes some other test in the class to fail.");
+        //                return;
+        //            }
+        //        }
+    }
+
+    private boolean runMvnInstall() throws MavenInvocationException {
+        // TODO: Maybe support custom command lines/options?
+        final InvocationRequest request = new DefaultInvocationRequest();
+        request.setGoals(Arrays.asList("install"));
+        request.setPomFile(project.getFile());
+        request.setProperties(new Properties());
+        request.getProperties().setProperty("skipTests", "true");
+
+        // TODO: Log the output from the maven process somewhere
+        request.setOutputHandler(s -> {});
+        request.setErrorHandler(s -> {});
+
+        final Invoker invoker = new DefaultInvoker();
+        final InvocationResult result = invoker.execute(request);
+
+        if (result.getExitCode() != 0) {
+            if (result.getExecutionException() == null) {
+                throw new RuntimeException("Compilation failed with exit code " + result.getExitCode() + " for an unknown reason");
+            } else {
+                throw new RuntimeException(result.getExecutionException());
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
@@ -21,8 +21,6 @@ import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import scala.Option;
 
-import javax.tools.Diagnostic;
-import javax.tools.JavaFileObject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -79,7 +77,7 @@ public class CleanerFixerPlugin extends TestPlugin {
                     Files.write(DetectorPathManager.originalOrderPath(), DetectorPlugin.getOriginalOrder(project));
                 }
 
-                // TODO: Modify so that it will read parameters directly from the
+                // TODO: Modify so that it will read parameters directly from the minimized files
                 setupAndApplyFix();
             } else {
                 final String errorMsg = "Module is not using a supported test framework (probably not JUnit).";
@@ -135,8 +133,6 @@ public class CleanerFixerPlugin extends TestPlugin {
         backup(victimMethod.javaFile());
 
         // Compile the test without our fix
-//        tryRecompile(victimMethod.javaFile());
-
         runMvnInstall();
 
         // Check if we pass in isolation before fix
@@ -156,8 +152,7 @@ public class CleanerFixerPlugin extends TestPlugin {
         victimMethod.prepend(cleanerStmts);
         victimMethod.javaFile().writeAndReloadCompilationUnit();
 
-        // Check if we pass in isolation after fix
-//        tryRecompile(victimMethod.javaFile());
+        // Recompile and check if we pass in isolation after fix
         runMvnInstall();
 
         // TODO: Output to result files rather than stdout

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerPathManager.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerPathManager.java
@@ -1,0 +1,36 @@
+package edu.illinois.cs.dt.tools.fixer;
+
+import com.reedoei.testrunner.mavenplugin.TestPluginPlugin;
+import edu.illinois.cs.dt.tools.utility.PathManager;
+import org.apache.commons.io.FilenameUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class CleanerPathManager extends PathManager {
+    public static final String BACKUP_EXTENSION = ".orig";
+
+    public static Path backupPath(final Path path) {
+        if (path.getParent() == null) {
+            return Paths.get(path.getFileName().toString() + BACKUP_EXTENSION);
+        } else {
+            return path.getParent().resolve(path.getFileName().toString() + BACKUP_EXTENSION);
+        }
+    }
+
+    // TODO: Move to a utility class (and eunomia)
+    public static Path changeExtension(final Path path, final String newExtension) {
+        final String extToAdd = newExtension.startsWith(".") ? newExtension : "." + newExtension;
+
+        return path.toAbsolutePath().getParent().resolve(FilenameUtils.removeExtension(path.getFileName().toString()) + extToAdd);
+    }
+
+    public static Path compiledPath(final Path sourcePath) {
+        final Path testSrcDir = Paths.get(TestPluginPlugin.mavenProject().getBuild().getTestSourceDirectory());
+        final Path testBinDir = Paths.get(TestPluginPlugin.mavenProject().getBuild().getTestOutputDirectory());
+
+        final Path relative = testSrcDir.relativize(sourcePath.toAbsolutePath());
+
+        return testBinDir.resolve(changeExtension(relative, "class"));
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/FailingTestDetector.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/FailingTestDetector.java
@@ -1,0 +1,41 @@
+package edu.illinois.cs.dt.tools.fixer;
+
+import com.reedoei.testrunner.data.results.Result;
+import com.reedoei.testrunner.data.results.TestRunResult;
+import edu.illinois.cs.dt.tools.runner.InstrumentingSmartRunner;
+import scala.util.Try;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public class FailingTestDetector {
+    private final InstrumentingSmartRunner runner;
+
+    public FailingTestDetector(final InstrumentingSmartRunner runner) {
+        this.runner = runner;
+    }
+
+    public Optional<Set<String>> notPassingTests(final List<String> tests) {
+        final Set<String> notPassingTests = new HashSet<>();
+
+        if (tests.isEmpty()) {
+            return Optional.of(notPassingTests);
+        }
+
+        final Try<TestRunResult> testRunResultTry = runner.runList(tests);
+
+        if (testRunResultTry.isSuccess()) {
+            testRunResultTry.get().results().forEach((testName, res) -> {
+                if (!res.result().equals(Result.PASS)) {
+                    notPassingTests.add(testName);
+                }
+            });
+
+            return Optional.of(notPassingTests);
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
@@ -1,0 +1,333 @@
+package edu.illinois.cs.dt.tools.fixer;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.Position;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.ast.visitor.Visitable;
+import com.google.common.base.Preconditions;
+import org.apache.commons.io.FilenameUtils;
+import sun.misc.Cleaner;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A basic Java file which supports compiling/removing methods.
+ */
+public class JavaFile {
+    public static JavaFile loadFile(final Path path, final String classpath, final Path compiledOutputDir) throws IOException {
+        return new JavaFile(path, classpath, compiledOutputDir).loadClassList();
+    }
+
+    public static int countDiagnostics(final DiagnosticCollector<JavaFileObject> diagnostics,
+                                        final Diagnostic.Kind kind) {
+        return Math.toIntExact(diagnostics.getDiagnostics().stream().filter(diag -> diag.getKind().equals(kind)).count());
+    }
+
+    private CompilationUnit compilationUnit;
+    private List<ClassOrInterfaceDeclaration> classList = new ArrayList<>();
+    private Map<ClassOrInterfaceDeclaration, List<MethodDeclaration>> classToMethods = new HashMap<>();
+    private Map<ClassOrInterfaceDeclaration, List<MethodDeclaration>> classToTestMethods = new HashMap<>();
+    private final Path path;
+    private final String classPath;
+    private final Path compiledOutputDir;
+
+    private JavaFile(final Path path, final String classPath, final Path compiledOutputDir) {
+        this.path = path;
+        this.classPath = classPath;
+        this.compiledOutputDir = compiledOutputDir;
+    }
+
+    public List<Diagnostic<? extends JavaFileObject>> compile() throws Exception {
+        final DiagnosticCollector<JavaFileObject> diagnostics = tryCompile();
+
+        return diagnostics.getDiagnostics().stream()
+                .filter(diag -> diag.getKind().equals(Diagnostic.Kind.ERROR))
+                .collect(Collectors.toList());
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    public CompilationUnit compilationUnit() {
+        return compilationUnit;
+    }
+
+    public Path compiledOutputPath() {
+        return compiledOutputDir;
+    }
+
+    /**
+     * Finds all classes/interfaces in the file and saves them.
+     */
+    private JavaFile loadClassList() throws IOException {
+        compilationUnit = JavaParser.parse(path);
+
+        classList.clear();
+        classList.addAll(compilationUnit.findAll(ClassOrInterfaceDeclaration.class));
+
+        classToMethods.clear();
+        for (final ClassOrInterfaceDeclaration classDec : classList) {
+           final List<MethodDeclaration> methods = classDec.findAll(MethodDeclaration.class);
+           classToMethods.put(classDec, methods);
+        }
+
+        classToTestMethods.clear();
+        classToMethods.forEach((classDec, methods) -> {
+            final List<MethodDeclaration> testMethods = new ArrayList<>();
+            for (final MethodDeclaration method : methods) {
+                if (areJUnitAnnotations(method.getAnnotations()) ||
+                        method.getNameAsString().startsWith("test")) {
+                    testMethods.add(method);
+                }
+            }
+            if (!testMethods.isEmpty()) {
+                classToTestMethods.put(classDec, testMethods);
+            }
+        });
+
+        return this;
+    }
+
+    private boolean areJUnitAnnotations(final List<AnnotationExpr> annotations) {
+        return annotations.stream().anyMatch(expr -> expr.getNameAsString().startsWith("Test"));
+    }
+
+    public List<String> getTestListAsString() {
+        final List<String> retList = new ArrayList<>();
+        for (final ClassOrInterfaceDeclaration classDec : classToTestMethods.keySet()) {
+            for (final MethodDeclaration method : classToTestMethods.get(classDec)) {
+                retList.add(getFullyQualifiedMethodName(method, classDec));
+            }
+        }
+        return retList;
+    }
+
+    private void writeFile() throws IOException {
+        Files.write(path(), compilationUnit.toString().getBytes());
+    }
+
+    public void writeAndReloadCompilationUnit() throws IOException {
+        System.out.println(compilationUnit);
+        writeFile();
+        loadClassList();
+    }
+
+    public MethodDeclaration findMethodAt(final long line) {
+        for (final ClassOrInterfaceDeclaration classDeclaration : classList) {
+            for (final BodyDeclaration bodyDeclaration : classDeclaration.getMembers()) {
+                if (bodyDeclaration instanceof MethodDeclaration) {
+                    final MethodDeclaration method = (MethodDeclaration)bodyDeclaration;
+                    final Position begin = method.getBegin().orElseThrow(() -> new RuntimeException("Cannot get start line for " + method.getSignature()));
+                    final Position end = method.getEnd().orElseThrow(() -> new RuntimeException("Cannot get end line for " + method.getSignature()));
+
+                    if (begin.line <= line && end.line >= line) {
+                        return method;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public MethodDeclaration findMethodDeclaration(final String name) {
+        for (final ClassOrInterfaceDeclaration classDeclaration : classList) {
+            for (final BodyDeclaration bodyDeclaration : classDeclaration.getMembers()) {
+                if (bodyDeclaration instanceof MethodDeclaration) {
+                    final MethodDeclaration method = (MethodDeclaration)bodyDeclaration;
+                    final String fullMethodName = getFullyQualifiedMethodName(method, classDeclaration);
+                    if (fullMethodName.equalsIgnoreCase(name)) {
+                        return method;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String getFullyQualifiedMethodName(MethodDeclaration method, ClassOrInterfaceDeclaration classDec) {
+        final Optional<PackageDeclaration> packageDec = compilationUnit.getPackageDeclaration();
+
+        Preconditions.checkArgument(packageDec.isPresent(), "No package declaration found for class: " + classDec.getNameAsString());
+
+        return String.format("%s.%s.%s",
+                packageDec.get().getName().toString(),
+                classDec.getNameAsString(),
+                method.getName().getIdentifier());
+    }
+
+
+    /**
+     * Attempts to remove the method declaration.
+     * @param method The method declaration to remove.
+     * @return A String of the fully qualified name of the method removed if found, null otherwise.
+     */
+    public String removeMethod(final MethodDeclaration method) {
+        for (final ClassOrInterfaceDeclaration classDeclaration : classList) {
+            final MethodRemoverVisitor remover = new MethodRemoverVisitor(method);
+            classDeclaration.accept(remover, null);
+
+            final Optional<PackageDeclaration> packageDec = compilationUnit.getPackageDeclaration();
+
+            if (remover.succeeded()) {
+                return createRemovedMethodString(packageDec.map(PackageDeclaration::getNameAsString).orElse(""), classDeclaration, method);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return The fully qualified name of this method: packageName.className.methodName(paramNames)
+     */
+    private static String createRemovedMethodString(final String packageName,
+                                                    final ClassOrInterfaceDeclaration classDeclaration,
+                                                    final MethodDeclaration method) {
+        // Not using .getDeclarationAsString because it includes the return type, which wouldn't work with concatting below
+        final String methodName = method.getName() + "(" + getParametersAsString(method) + ")";
+
+        return packageName + classDeclaration.getName() + "." + methodName;
+    }
+
+    /**
+     * Ex: For int f(int a, int b), returns "int a, int b"
+     * @return A string containing the parameters separated by commas.
+     */
+    private static String getParametersAsString(final MethodDeclaration method) {
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < method.getParameters().size(); i++) {
+            final Parameter parameter = method.getParameters().get(i);
+
+            result.append(parameter.toString());
+
+            if (i != (method.getParameters().size() - 1)) {
+                result.append(", ");
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Writes the file to the output path, then tries to compile the output file.
+     */
+    private DiagnosticCollector<JavaFileObject> tryCompile() throws IOException {
+        writeAndReloadCompilationUnit();
+        return runCompilation();
+    }
+
+    private DiagnosticCollector<JavaFileObject> runCompilation() throws IOException {
+        final File file = Objects.requireNonNull(path()).toFile();
+
+        final JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
+        final List<String> compilerOptions =
+                new ArrayList<>(Arrays.asList("-classpath", classPath));
+
+        final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+
+        try (final StandardJavaFileManager fileManager =
+                     javaCompiler.getStandardFileManager(diagnostics, null, null)) {
+            final Iterable<? extends JavaFileObject> fileObjects =
+                    fileManager.getJavaFileObjectsFromFiles(Collections.singletonList(file));
+
+            final JavaCompiler.CompilationTask compilationTask =
+                    javaCompiler.getTask(null, fileManager, diagnostics, compilerOptions, null, fileObjects);
+            compilationTask.call();
+
+            // Move to compile output path
+            final Path compiledPath = CleanerPathManager.changeExtension(path(), "class");
+            final Path outputPath = CleanerPathManager.compiledPath(path());
+
+            System.out.println("[INFO] Compiling to " + outputPath);
+            Files.move(compiledPath, outputPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        return diagnostics;
+    }
+
+    public List<MethodDeclaration> getMethodsWithErrors(DiagnosticCollector<JavaFileObject> diagnostics)
+            throws Exception {
+        final List<MethodDeclaration> methodsWithErrors = new ArrayList<>();
+
+        for (Diagnostic diagnostic : diagnostics.getDiagnostics()) {
+            if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
+                final MethodDeclaration method = findMethodAt(diagnostic.getLineNumber());
+                if (method != null) {
+                    if (!methodsWithErrors.contains(method)) {
+                        methodsWithErrors.add(method);
+                    }
+                } else {
+                    throw new Exception("An error has occurred in an unknown method:\n"
+                                                + " Message: " + diagnostic.getMessage(Locale.getDefault()) + "\n"
+                                                + " Source: " + diagnostic.getSource() + "\n"
+                                                + " Code: " + diagnostic.getCode() + "\n"
+                                                + " Kind: " + diagnostic.getKind() + "\n"
+                                                + " Line: " + diagnostic.getLineNumber()
+                                                + " Position: " + diagnostic.getPosition() + "\n");
+                }
+            } else {
+                System.out.println("Ignoring the following diagnostic: "
+                                           + diagnostic.getMessage(Locale.getDefault()));
+            }
+        }
+
+        return methodsWithErrors;
+    }
+
+
+    private final class MethodRemoverVisitor extends ModifierVisitor<Void> {
+        private final MethodDeclaration method;
+
+        private boolean found = false;
+
+        MethodRemoverVisitor(final MethodDeclaration method) {
+            this.method = method;
+        }
+
+        @Override
+        public Visitable visit(MethodDeclaration n, Void arg) {
+            if (n.getSignature().equals(method.getSignature())) {
+                this.found = true;
+
+                return null;
+            }
+
+            return super.visit(n, arg);
+        }
+
+        boolean succeeded() {
+            return found;
+        }
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
@@ -12,8 +12,6 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import com.google.common.base.Preconditions;
-import org.apache.commons.io.FilenameUtils;
-import sun.misc.Cleaner;
 
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -25,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
@@ -1,0 +1,69 @@
+package edu.illinois.cs.dt.tools.fixer;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+public class JavaMethod {
+    public static Optional<JavaMethod> find(final String methodName, final List<Path> files,
+                                            final String classpath)
+            throws IOException {
+        for (final Path file : files) {
+            if (Files.exists(file) && FilenameUtils.isExtension(file.getFileName().toString(), "java")) {
+                final JavaFile javaFile = JavaFile.loadFile(file, classpath, CleanerPathManager.compiledPath(file).getParent());
+
+                final MethodDeclaration methodDeclaration = javaFile.findMethodDeclaration(methodName);
+
+                if (methodDeclaration != null) {
+                    return Optional.of(new JavaMethod(methodName, javaFile, methodDeclaration));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private final String methodName;
+    private final JavaFile javaFile;
+    private final MethodDeclaration method;
+    private final BlockStmt body;
+
+    private JavaMethod(final String methodName, final JavaFile javaFile, final MethodDeclaration method) {
+        this.methodName = methodName;
+        this.javaFile = javaFile;
+        this.method = method;
+        this.body = method().getBody()
+                .orElseThrow(() -> new IllegalArgumentException("Method " + methodName + " has no body!"));
+    }
+
+    public JavaFile javaFile() {
+        return javaFile;
+    }
+
+    public MethodDeclaration method() {
+        return method;
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public BlockStmt body() {
+        return body;
+    }
+
+    public void prepend(final NodeList<Statement> stmts) {
+        final NodeList<Statement> statements = body.getStatements();
+        statements.add(0, new BlockStmt(stmts));
+
+        javaFile().findMethodDeclaration(methodName()).setBody(new BlockStmt(statements));
+    }
+}

--- a/src/main/java/edu/illinois/cs/dt/tools/utility/ErrorLogger.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/utility/ErrorLogger.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 
 public class ErrorLogger {
@@ -25,6 +26,23 @@ public class ErrorLogger {
 
     public String coordinates() {
         return coordinates;
+    }
+
+    private String subjectName(final MavenProject project) {
+        final Path relativePath =
+                PathManager.parentPath().getParent().toAbsolutePath()
+                        .relativize(project.getBasedir().toPath().toAbsolutePath());
+
+        return relativePath.toString().replace("/", "-");
+    }
+
+    public void writeSubjectProperties() throws IOException {
+        final Properties properties = new Properties();
+        properties.setProperty("subject.coordinates", coordinates);
+        properties.setProperty("subject.name", subjectName(project));
+
+        Files.createDirectories(DiagnoserPathManager.subjectProperties().getParent());
+        properties.store(new FileOutputStream(DiagnoserPathManager.subjectProperties().toFile()), "");
     }
 
     public <T> Optional<T> runAndLogError(final Callable<T> callable) {


### PR DESCRIPTION
This is the implementation of "ASDF", transferred over from the dependent-tests-impact repository (see https://github.com/winglam/dependent-tests-impact/pull/27).

Example:
```
(git clone https://github.com/ReedOei/testrunner && cd testrunner && mvn install)
(git clone https://github.com/ReedOei/dt-fixing-tools && cd dt-fixing-tools && git checkout cleaner-fixer && mvn install)

git clone https://github.com/ReedOei/testpluginexamplejava
cd testpluginexamplejava
mvn install -fn |& tee mvn-test.log

# Add plugin to pom.xml as described in README on https://github.com/ReedOei/dt-fixing-tools, except using `<className>edu.illinois.cs.dt.tools.fixer.CleanerFixerPlugin</className>`

mvn testrunner:testplugin -e -Ddt_fixer.cleaner=com.reedoei.testrunner.example.java.ConfigTest.bTestResetCleaner -Ddt_fixer.victim=com.reedoei.testrunner.example.java.ConfigTest.cTestDefaultSettingsVictim -Ddt_fixer.polluter=com.reedoei.testrunner.example.java.ConfigTest.aTestSetPolluter |& tee log.txt
```

Output should be:
```
DIAGNOSER_MODULE_COORDINATES: com.reedoei:testplugin-example-java:1.0-SNAPSHOT
[WARN] Maven will be executed in interactive mode, but no input stream has been configured for this MavenInvoker instance.
[INFO] Running victim test in isolation without code from cleaner.
[INFO] Applying code from cleaner and recompiling.
package com.reedoei.testrunner.example.java;

import org.junit.FixMethodOrder;
import org.junit.Test;
import org.junit.runners.MethodSorters;
import static org.junit.Assert.*;

// use this to ensure that dependency does not manifest in the default order
@FixMethodOrder(MethodSorters.NAME_ASCENDING)
public class ConfigTest {

    @Test
    public void aTestSetPolluter() {
        Config.settingA(10);
        assertEquals(10, Config.settingA());
        Config.settingB(5);
        assertEquals(5, Config.settingB());
    }

    @Test
    public void bTestResetCleaner() {
        Config.settingA(92);
        Config.settingB(5);
        Config.reset();
        assertEquals(0, Config.settingA());
        assertEquals(0, Config.settingB());
    }

    @Test
    public void cTestDefaultSettingsVictim() {
        {
            Config.settingA(92);
            Config.settingB(5);
            Config.reset();
            assertEquals(0, Config.settingA());
            assertEquals(0, Config.settingB());
        }
        assertEquals(0, Config.settingA());
        assertEquals(0, Config.settingB());
    }
}

[WARN] Maven will be executed in interactive mode, but no input stream has been configured for this MavenInvoker instance.
[INFO] Running victim test in isolation with code from cleaner.
[INFO] Fix was successful! Fixed file:
/home/roei/Java/testpluginexamplejava/src/test/java/com/reedoei/testrunner/example/java/ConfigTest.java
```