### PR TITLE
Adding logic for doing delta-debugging of the cleaner code

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
@@ -137,7 +137,14 @@ public class CleanerFixerPlugin extends TestPlugin {
         victimMethod.javaFile().writeAndReloadCompilationUnit();
 
         // Rebuild and see if tests run properly
-        runMvnInstall();
+        try {
+            runMvnInstall();
+        } catch (Exception ex) {
+            TestPluginPlugin.info("Error building the code, passed in cleaner does not work");
+            // Reset the change
+            victimMethod.removeFirstBlock();
+            return false;
+        }
         // TODO: Output to result files rather than stdout
         TestPluginPlugin.info("Running victim test with code from cleaner.");
         List<String> tests;

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
@@ -66,4 +66,12 @@ public class JavaMethod {
 
         javaFile().findMethodDeclaration(methodName()).setBody(new BlockStmt(statements));
     }
+
+    // Helper method needed for delta-debugging to "reset" the state by removing that added first block
+    public void removeFirstBlock() {
+        final NodeList<Statement> statements = body.getStatements();
+        statements.remove(0);
+
+        javaFile().findMethodDeclaration(methodName()).setBody(new BlockStmt(statements));
+    }
 }


### PR DESCRIPTION
This pull request concerns augmenting the existing cleaner copying logic to do delta debugging on the cleaner statements. Lowest granularity is at the statement level, so the smallest amount of code should consist of one statement.

Currently the major thing that is missing is that the cleaner statements brought in should consider statements from the class's setup and teardown methods. I'm currently working on that part, but this is the first initial delta debugging logic that works just on the cleaner test's body.