### PR TITLE
Augmenting cleaner fixer logic to include setup/teardown code

### DIFF
--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/CleanerFixerPlugin.java
@@ -4,7 +4,6 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.Statement;
-import com.reedoei.eunomia.collections.ListUtil;
 import com.reedoei.testrunner.configuration.Configuration;
 import com.reedoei.testrunner.data.results.Result;
 import com.reedoei.testrunner.mavenplugin.TestPlugin;
@@ -28,7 +27,6 @@ import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
-import org.apache.maven.shared.invoker.SystemOutHandler;
 import scala.Option;
 
 import java.io.File;
@@ -330,12 +328,13 @@ public class CleanerFixerPlugin extends TestPlugin {
         if (!getClassName(cleanerMethod.methodName()).equals(getClassName(victimMethod.methodName()))) {
             cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.javaFile(), "@BeforeClass"));
         }
+        // Note: logic assumes methods are annotated with annotations that have been imported, so things like @org.junit.Before are not considered
         cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.javaFile(), "@Before"));
         cleanerStmts.addAll(cleanerMethod.body().getStatements());
         cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.javaFile(), "@After"));
         // Only include AfterClass if in separate classes
         if (!getClassName(cleanerMethod.methodName()).equals(getClassName(victimMethod.methodName()))) {
-            cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.javaFile(), "@AfterClassClass"));
+            cleanerStmts.addAll(getCodeFromAnnotatedMethod(cleanerMethod.javaFile(), "@AfterClass"));
         }
 
         if (!checkCleanerStmts(failingOrder, victimMethod, cleanerStmts)) {
@@ -361,10 +360,8 @@ public class CleanerFixerPlugin extends TestPlugin {
         request.getProperties().setProperty("rat.skip", "true");
 
         // TODO: Log the output from the maven process somewhere
-        //request.setOutputHandler(s -> {});
-        request.setOutputHandler(new SystemOutHandler());
-        //request.setErrorHandler(s -> {});
-        request.setErrorHandler(new SystemOutHandler());
+        request.setOutputHandler(s -> {});
+        request.setErrorHandler(s -> {});
 
         final Invoker invoker = new DefaultInvoker();
         final InvocationResult result = invoker.execute(request);

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
@@ -172,6 +172,24 @@ public class JavaFile {
         return null;
     }
 
+    public List<MethodDeclaration> findMethodsWithAnnotation(String annotation) {
+        List<MethodDeclaration> methods = new ArrayList<MethodDeclaration>();
+        for (final ClassOrInterfaceDeclaration classDeclaration : classList) {
+            for (final BodyDeclaration bodyDeclaration : classDeclaration.getMembers()) {
+                if (bodyDeclaration instanceof MethodDeclaration) {
+                    final MethodDeclaration method = (MethodDeclaration)bodyDeclaration;
+                    for (int i = 0; i < method.getAnnotations().size(); i++) {
+                        if (method.getAnnotations().get(i).toString().equals(annotation)) {
+                            methods.add(method);
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        return methods;
+    }
+
     private String getFullyQualifiedMethodName(MethodDeclaration method, ClassOrInterfaceDeclaration classDec) {
         final Optional<PackageDeclaration> packageDec = compilationUnit.getPackageDeclaration();
 

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaFile.java
@@ -173,15 +173,15 @@ public class JavaFile {
     }
 
     public List<MethodDeclaration> findMethodsWithAnnotation(String annotation) {
-        List<MethodDeclaration> methods = new ArrayList<MethodDeclaration>();
+        List<MethodDeclaration> methods = new ArrayList<>();
         for (final ClassOrInterfaceDeclaration classDeclaration : classList) {
             for (final BodyDeclaration bodyDeclaration : classDeclaration.getMembers()) {
                 if (bodyDeclaration instanceof MethodDeclaration) {
                     final MethodDeclaration method = (MethodDeclaration)bodyDeclaration;
-                    for (int i = 0; i < method.getAnnotations().size(); i++) {
-                        if (method.getAnnotations().get(i).toString().equals(annotation)) {
+                    for (AnnotationExpr annotationExpr : method.getAnnotations()) {
+                        if (annotationExpr.toString().equals(annotation)) {
                             methods.add(method);
-                            continue;
+                            break;
                         }
                     }
                 }

--- a/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
+++ b/src/main/java/edu/illinois/cs/dt/tools/fixer/JavaMethod.java
@@ -60,6 +60,11 @@ public class JavaMethod {
         return body;
     }
 
+    // Small helper to get class name from fully-qualified name of method
+    public String getClassName() {
+        return methodName.substring(0, methodName.lastIndexOf('.'));
+    }
+
     public void prepend(final NodeList<Statement> stmts) {
         final NodeList<Statement> statements = body.getStatements();
         statements.add(0, new BlockStmt(stmts));


### PR DESCRIPTION
This PR adds setup/teardown code as part of the cleaner statements to minimize. Note that it looks for the annotated methods using the javaparser API, so it's based on parsing the source code.